### PR TITLE
Fix resource link temporarily

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,7 +2,7 @@ module.exports = {
   title: 'Trends in Web Development',
   tagline: 'Course offered by Cornell DTI',
   url: 'https://web-dev.cornelldti.org',
-  baseUrl: '/',
+  baseUrl: '/trends-in-web-dev-website',
   favicon: 'img/logo.png',
   organizationName: 'cornell-dti',
   projectName: 'trends-in-web-dev-website',


### PR DESCRIPTION
Before we enable a custom domain for this GitHub page, we need to use the project prefix temporarily