### PR TITLE
Use personal access token for GitHub pages deployment

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Yarn Install
         run: yarn install
       - name: Build & Deploy Website
+        env:
+          GIT_USER: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
         run: |
           git config --global user.name "deployment-bot"
-          GIT_USER=x-access-token:${{ github.token }} yarn deploy
+          yarn deploy


### PR DESCRIPTION
GITHUB_TOKEN cannot trigger auto page deployment