### PR TITLE
Only run linter in CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -12,5 +12,3 @@ jobs:
         run: yarn install
       - name: Run Prettier
         run: 'yarn format:check'
-      - name: Build Website
-        run: yarn build


### PR DESCRIPTION
Testing of build is now handled by netlify.
Click details of the `netlify/webdev-cornelldti/deploy-preview` job to see the preview!