### PR TITLE
Mark files in .yarn as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+.yarn/** linguist-generated=true


### PR DESCRIPTION
Make github ignore these files when computing language stat, so that the repo is TS majority again.