### PR TITLE
fix links to support trailing slash

### DIFF
--- a/versioned_docs/version-2020fa/HackOurCampus.md
+++ b/versioned_docs/version-2020fa/HackOurCampus.md
@@ -79,10 +79,10 @@ You should get a link like https://todo-RANDOMHASH-uc.a.run.app/products. **Copy
 
 #### Example Code
 
-For the frontend, we used the example code [here](../lecture7#filterable-product-table-example) taken from React docs [here](https://reactjs.org/docs/thinking-in-react.html), but instead of declaring all the products in the `App` component, we make a GET call to our backend `/products` endpoint in the `FilterableProductTable` to fetch the products list. The relevant changes are below:
+For the frontend, we used the example code [here](/docs/lecture7#filterable-product-table-example) taken from React docs [here](https://reactjs.org/docs/thinking-in-react.html), but instead of declaring all the products in the `App` component, we make a GET call to our backend `/products` endpoint in the `FilterableProductTable` to fetch the products list. The relevant changes are below:
 
 :::note
-If you want to learn more about setting up a frontend React application, check out lecture [5](../lecture5), [6](../lecture6), [7](../lecture7), [8](../lecture8).
+If you want to learn more about setting up a frontend React application, check out lecture [5](/docs/lecture5), [6](/docs/lecture6), [7](/docs/lecture7), [8](/docs/lecture8).
 :::
 
 ```jsx title="App.js"

--- a/versioned_docs/version-2020fa/HackOurCampus.md
+++ b/versioned_docs/version-2020fa/HackOurCampus.md
@@ -79,10 +79,10 @@ You should get a link like https://todo-RANDOMHASH-uc.a.run.app/products. **Copy
 
 #### Example Code
 
-For the frontend, we used the example code [here](./lecture7#filterable-product-table-example) taken from React docs [here](https://reactjs.org/docs/thinking-in-react.html), but instead of declaring all the products in the `App` component, we make a GET call to our backend `/products` endpoint in the `FilterableProductTable` to fetch the products list. The relevant changes are below:
+For the frontend, we used the example code [here](../lecture7#filterable-product-table-example) taken from React docs [here](https://reactjs.org/docs/thinking-in-react.html), but instead of declaring all the products in the `App` component, we make a GET call to our backend `/products` endpoint in the `FilterableProductTable` to fetch the products list. The relevant changes are below:
 
 :::note
-If you want to learn more about setting up a frontend React application, check out lecture [5](./lecture5), [6](./lecture6), [7](./lecture7), [8](./lecture8).
+If you want to learn more about setting up a frontend React application, check out lecture [5](../lecture5), [6](../lecture6), [7](../lecture7), [8](../lecture8).
 :::
 
 ```jsx title="App.js"

--- a/versioned_docs/version-2020fa/assignment1.md
+++ b/versioned_docs/version-2020fa/assignment1.md
@@ -20,7 +20,7 @@ yarn add --dev typescript ts-node @types/express
 ```
 
 :::info
-Check out [lecture1](./lecture1) for more details on how this setup works!
+Check out [lecture1](../lecture1) for more details on how this setup works!
 :::
 
 Now you can create an `index.ts` file to add your routes and assignment code in.
@@ -51,7 +51,7 @@ To test your code run `ts-node index.ts`. Your server should be up and running (
 
 ## Getting help
 
-If you're stuck, we have [TA office hours](./introduction#when-are-office-hours) every week day so feel free to come and ask questions! In addition, you can join the [Piazza](http://piazza.com/cornell/fall2020/info1998section604) and post your question. Please make it public if it's just a general question with no code screenshots, otherwise make it private.
+If you're stuck, we have [TA office hours](../introduction#when-are-office-hours) every week day so feel free to come and ask questions! In addition, you can join the [Piazza](http://piazza.com/cornell/fall2020/info1998section604) and post your question. Please make it public if it's just a general question with no code screenshots, otherwise make it private.
 
 ## Submission
 

--- a/versioned_docs/version-2020fa/assignment1.md
+++ b/versioned_docs/version-2020fa/assignment1.md
@@ -20,7 +20,7 @@ yarn add --dev typescript ts-node @types/express
 ```
 
 :::info
-Check out [lecture1](../lecture1) for more details on how this setup works!
+Check out [lecture1](/docs/lecture1) for more details on how this setup works!
 :::
 
 Now you can create an `index.ts` file to add your routes and assignment code in.
@@ -51,7 +51,7 @@ To test your code run `ts-node index.ts`. Your server should be up and running (
 
 ## Getting help
 
-If you're stuck, we have [TA office hours](../introduction#when-are-office-hours) every week day so feel free to come and ask questions! In addition, you can join the [Piazza](http://piazza.com/cornell/fall2020/info1998section604) and post your question. Please make it public if it's just a general question with no code screenshots, otherwise make it private.
+If you're stuck, we have [TA office hours](/docs/introduction#when-are-office-hours) every week day so feel free to come and ask questions! In addition, you can join the [Piazza](http://piazza.com/cornell/fall2020/info1998section604) and post your question. Please make it public if it's just a general question with no code screenshots, otherwise make it private.
 
 ## Submission
 

--- a/versioned_docs/version-2020fa/assignment2.md
+++ b/versioned_docs/version-2020fa/assignment2.md
@@ -88,7 +88,7 @@ that specific one, make sure you add it back, because we will be testing
 that it is there).
 
 :::tip
-Don't know where to start? Reference the [live coding demo Posts example](./lecture3#SampleCode) from lecture 3! Also, get help in [office hours](introduction#when-are-office-hours)!
+Don't know where to start? Reference the [live coding demo Posts example](../lecture3#SampleCode) from lecture 3! Also, get help in [office hours](introduction#when-are-office-hours)!
 :::
 
 ## Part 7: Submission

--- a/versioned_docs/version-2020fa/assignment2.md
+++ b/versioned_docs/version-2020fa/assignment2.md
@@ -88,7 +88,7 @@ that specific one, make sure you add it back, because we will be testing
 that it is there).
 
 :::tip
-Don't know where to start? Reference the [live coding demo Posts example](../lecture3#SampleCode) from lecture 3! Also, get help in [office hours](introduction#when-are-office-hours)!
+Don't know where to start? Reference the [live coding demo Posts example](/docs/lecture3#SampleCode) from lecture 3! Also, get help in [office hours](introduction#when-are-office-hours)!
 :::
 
 ## Part 7: Submission

--- a/versioned_docs/version-2020fa/assignments.md
+++ b/versioned_docs/version-2020fa/assignments.md
@@ -5,6 +5,6 @@ title: Assignments
 
 Assignments will be released here after lecture!
 
-[Assignment 1](../assignment1): Due on CMS **10/2 at 11:59pm**
+[Assignment 1](/docs/assignment1): Due on CMS **10/2 at 11:59pm**
 
-[Assignment 2](../assignment2): Due on CMS **10/13 at 3:59pm**
+[Assignment 2](/docs/assignment2): Due on CMS **10/13 at 3:59pm**

--- a/versioned_docs/version-2020fa/assignments.md
+++ b/versioned_docs/version-2020fa/assignments.md
@@ -5,6 +5,6 @@ title: Assignments
 
 Assignments will be released here after lecture!
 
-[Assignment 1](./assignment1): Due on CMS **10/2 at 11:59pm**
+[Assignment 1](../assignment1): Due on CMS **10/2 at 11:59pm**
 
-[Assignment 2](./assignment2): Due on CMS **10/13 at 3:59pm**
+[Assignment 2](../assignment2): Due on CMS **10/13 at 3:59pm**

--- a/versioned_docs/version-2020fa/introduction.md
+++ b/versioned_docs/version-2020fa/introduction.md
@@ -65,7 +65,7 @@ Lecture 10 11/24: Student Choice
 
 ## Where are assignments released and submitted?
 
-Assignments will be released on [here](./assignments) every Tuesday. Every assignment
+Assignments will be released on [here](../assignments) every Tuesday. Every assignment
 is due right before class of the following week at 3:59pm unless otherwise stated. You will have 6 slip days total to use on
 the assignments, but for each assignment, you may only use up to 2 slip days. Use these judiciously because we will not be handling extensions outside of slip days.
 

--- a/versioned_docs/version-2020fa/introduction.md
+++ b/versioned_docs/version-2020fa/introduction.md
@@ -65,7 +65,7 @@ Lecture 10 11/24: Student Choice
 
 ## Where are assignments released and submitted?
 
-Assignments will be released on [here](../assignments) every Tuesday. Every assignment
+Assignments will be released on [here](/docs/assignments) every Tuesday. Every assignment
 is due right before class of the following week at 3:59pm unless otherwise stated. You will have 6 slip days total to use on
 the assignments, but for each assignment, you may only use up to 2 slip days. Use these judiciously because we will not be handling extensions outside of slip days.
 

--- a/versioned_docs/version-2020fa/lecture1.md
+++ b/versioned_docs/version-2020fa/lecture1.md
@@ -7,7 +7,7 @@ title: Lecture 1
 
 [Lecture Slides](https://docs.google.com/presentation/d/1a3qkQruToLPrxLdNk06f30XIVgMavLr8n5KQah_7YRY/edit?usp=sharing)
 
-[Assignment 1](./assignment1) due **10/2 11:59pm**
+[Assignment 1](../assignment1) due **10/2 11:59pm**
 
 **Join the [Piazza](https://piazza.com/cornell/fall2020/info1998section604)!**
 

--- a/versioned_docs/version-2020fa/lecture1.md
+++ b/versioned_docs/version-2020fa/lecture1.md
@@ -7,7 +7,7 @@ title: Lecture 1
 
 [Lecture Slides](https://docs.google.com/presentation/d/1a3qkQruToLPrxLdNk06f30XIVgMavLr8n5KQah_7YRY/edit?usp=sharing)
 
-[Assignment 1](../assignment1) due **10/2 11:59pm**
+[Assignment 1](/docs/assignment1) due **10/2 11:59pm**
 
 **Join the [Piazza](https://piazza.com/cornell/fall2020/info1998section604)!**
 

--- a/versioned_docs/version-2020fa/lecture3.md
+++ b/versioned_docs/version-2020fa/lecture3.md
@@ -7,7 +7,7 @@ title: Lecture 3
 
 [Lecture Slides](https://docs.google.com/presentation/d/11W-GdF6V9fgZyxzvjTrUieKTTIhoE7A30eZos86mfuo/edit?usp=sharing)
 
-[Assignment 2](../assignment2) due **10/13 03:59pm**
+[Assignment 2](/docs/assignment2) due **10/13 03:59pm**
 
 ## Before the lecture
 

--- a/versioned_docs/version-2020fa/lecture3.md
+++ b/versioned_docs/version-2020fa/lecture3.md
@@ -7,7 +7,7 @@ title: Lecture 3
 
 [Lecture Slides](https://docs.google.com/presentation/d/11W-GdF6V9fgZyxzvjTrUieKTTIhoE7A30eZos86mfuo/edit?usp=sharing)
 
-[Assignment 2](./assignment2) due **10/13 03:59pm**
+[Assignment 2](../assignment2) due **10/13 03:59pm**
 
 ## Before the lecture
 


### PR DESCRIPTION
If you go to https://webdev.cornelldti.org/docs/lecture3 (note the lack of a trailing slash), for example, whatever is hosting the site adds a trailing slash to the URL. This breaks local links, such as the one to the assignment page.

Note that when you navigate to a page through the sidebar, the trailing slash gets removed and all the local links work fine again.

Anyways, if you specify `/docs/page` rather than `./page`, you don't seem to have this issue anymore.