### PR TITLE
Fix CRA command in lecture 5 notes

### DIFF
--- a/versioned_docs/version-2020fa/lecture5.md
+++ b/versioned_docs/version-2020fa/lecture5.md
@@ -15,10 +15,12 @@ Assignment 4 COMING SOON due **10/27 3:59pm**
 ## Before the Lecture
 
 ```bash
-yarn create react-app lecture2
-cd lecture2
+yarn create react-app lecture5 --template typescript
+cd lecture5
 yarn start
 ```
+
+This creates a hot-reloading (refreshes automatically when edits are made) dev version of your React site, hosted at `localhost:3000`.
 
 ## Your First Component
 


### PR DESCRIPTION
in the command, it refers to lecture 2 rather than 5, and doesn't use `--template typescript`.


We might also want to consider removing the JavaScript tab and just only provide TypeScript code, since we're not using JS for this class @meganyin13 @ashneeldas2 