### PR TITLE
[homepage] Add link to join zoom lecture to homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -60,6 +60,15 @@ export default () => {
             >
               Start Learning
             </Link>
+            <Link
+              className={classnames(
+                'button button--primary button--lg',
+                styles.getStarted
+              )}
+              to="https://cornell.zoom.us/j/7293410777?pwd=UWxlMTh3VGd2ZXNXSUN6MnlEeFJjZz09"
+            >
+              Join Zoom Lecture
+            </Link>
           </div>
         </div>
       </header>

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -30,3 +30,7 @@
   height: 200px;
   width: 200px;
 }
+
+.getStarted {
+  margin: 1em;
+}


### PR DESCRIPTION
<img width="1301" alt="Screen Shot 2020-10-23 at 14 30 31" src="https://user-images.githubusercontent.com/4290500/97040712-56001880-153c-11eb-9d83-471d30980935.png">