### PR TITLE
[lecture5] Eliminate all anonymous default exports

### DIFF
--- a/versioned_docs/version-2020fa/lecture5.md
+++ b/versioned_docs/version-2020fa/lecture5.md
@@ -39,12 +39,14 @@ import React from 'react';
 
 type Props = { readonly name: string; readonly githubLink: string };
 
-export default ({ name, githubLink }: Props) => (
+const MyComponent = ({ name, githubLink }: Props) => (
   <div>
     <div>My name is {name}.</div>
     <a href={githubLink}>My GitHub</a>
   </div>
 );
+
+export default MyComponent;
 ```
 
 </TabItem>
@@ -53,12 +55,14 @@ export default ({ name, githubLink }: Props) => (
 ```jsx title="MyComponent.jsx"
 import React from 'react';
 
-export default ({ name, githubLink }) => (
+const MyComponent = ({ name, githubLink }) => (
   <div>
     <div>My name is {name}.</div>
     <a href={githubLink}>My GitHub</a>
   </div>
 );
+
+export default MyComponent;
 ```
 
 </TabItem>
@@ -277,12 +281,14 @@ import React from 'react';
 
 type Props = { readonly name: string; readonly githubLink: string };
 
-export default ({ name, githubLink }: Props) => (
+const MyComponent = ({ name, githubLink }: Props) => (
   <div>
     <div>My name is {name}.</div>
     <a href={githubLink}>My GitHub</a>
   </div>
 );
+
+export default MyComponent;
 ```
 
 </TabItem>
@@ -291,12 +297,14 @@ export default ({ name, githubLink }: Props) => (
 ```jsx title="MyComponent.jsx"
 import React from 'react';
 
-export default ({ name, githubLink }) => (
+const MyComponent = ({ name, githubLink }) => (
   <div>
     <div>My name is {name}.</div>
     <a href={githubLink}>My GitHub</a>
   </div>
 );
+
+export default MyComponent;
 ```
 
 </TabItem>
@@ -354,7 +362,6 @@ export default function SimpleEditor() {
     </div>
   );
 }
-const [stateVar, setterFunc] = useState(initValue);
 ```
 
 </TabItem>
@@ -387,7 +394,6 @@ export default function SimpleEditor() {
     </div>
   );
 }
-const [stateVar, setterFunc] = useState(initValue);
 ```
 
 </TabItem>


### PR DESCRIPTION
CRA released v4, and the bundled linter config will warn against this:

<img width="1136" alt="Screen Shot 2020-10-23 at 14 40 21" src="https://user-images.githubusercontent.com/4290500/97042005-69ac7e80-153e-11eb-8ce9-a222397d79f2.png">

Let's eliminate all all anonymous default exports so our lecture notes do not cause these annoying linter warnings.