### PR TITLE
Fix the wrapping of homepage buttons on mobile

### DIFF
--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -15,6 +15,7 @@
 
 .buttons {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
 }


### PR DESCRIPTION
Before:
<img width="356" alt="Screen Shot 2020-11-02 at 14 57 22" src="https://user-images.githubusercontent.com/4290500/97913077-ce748f80-1d1b-11eb-9f38-c506c99e1584.png">

After:
<img width="376" alt="Screen Shot 2020-11-02 at 14 57 13" src="https://user-images.githubusercontent.com/4290500/97913075-ce748f80-1d1b-11eb-8f02-62895ab00bbe.png">
