### PR TITLE
Add links to Firebase Auth docs for further info

### DIFF
--- a/versioned_docs/version-2020fa/lecture9.md
+++ b/versioned_docs/version-2020fa/lecture9.md
@@ -237,7 +237,7 @@ If the user is logged in, `SongList` will show. Otherwise they will be asked to 
 We then deployed this app on Firebase for the frontend and Heroku for the backend. Refer to the commands above.
 
 :::tip
-We recommend using Firebase's built-in support for Google Authentication since storing passwords securely is _very hard_ (more details in the security section). Firebase also has support for many other accounts such as Facebook, GitHub, Microsoft, Apple, etc. Read more about Firebase Authentication [here](https://firebase.google.com/docs/auth/web/firebaseui). If for whatever reason you really want to implement your own user accounts, Firebase can still help you store passwords securely. Read more [here](https://firebase.google.com/docs/auth/web/password-auth). 
+We recommend using Firebase's built-in support for Google Authentication since storing passwords securely is _very hard_ (more details in the security section). Firebase also has support for many other accounts such as Facebook, GitHub, Microsoft, Apple, etc. Read more about Firebase Authentication [here](https://firebase.google.com/docs/auth/web/firebaseui). If for whatever reason you really want to implement your own user accounts, Firebase can still help you store passwords securely. Read more [here](https://firebase.google.com/docs/auth/web/password-auth).
 :::
 
 ## Security

--- a/versioned_docs/version-2020fa/lecture9.md
+++ b/versioned_docs/version-2020fa/lecture9.md
@@ -236,6 +236,10 @@ If the user is logged in, `SongList` will show. Otherwise they will be asked to 
 
 We then deployed this app on Firebase for the frontend and Heroku for the backend. Refer to the commands above.
 
+:::tip
+We recommend using Firebase's built-in support for Google Authentication since storing passwords securely is _very hard_ (more details in the security section). Firebase also has support for many other accounts such as Facebook, GitHub, Microsoft, Apple, etc. Read more about Firebase Authentication [here](https://firebase.google.com/docs/auth/web/firebaseui). If for whatever reason you really want to implement your own user accounts, Firebase can still help you store passwords securely. Read more [here](https://firebase.google.com/docs/auth/web/password-auth). 
+:::
+
 ## Security
 
 Web app security is integral in a world where people have malicious intentions. As such, we advocate for at least these basic security measures.


### PR DESCRIPTION
For my next farm, I should create a Learn more docs page with links to useful documentation 👩‍🌾 🥕 