### PR TITLE
Replace deprecated ESLint VS Code settings

### DIFF
--- a/versioned_docs/version-2021sp/setup-editor.md
+++ b/versioned_docs/version-2021sp/setup-editor.md
@@ -20,8 +20,9 @@ Once installed, add these lines to your VSCode Settings (refer to [this link](ht
 ```json
   // Other settings ...
   "eslint.alwaysShowStatus": true,
-  "eslint.autoFixOnSave": true,
-  "eslint.enable": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   "eslint.packageManager": "yarn"
 ```
 


### PR DESCRIPTION
A student just pointed out to me that the ESLint instructions for rules in the `settings.json` have since been deprecated. Here are the updated versions. Note that `"eslint.enable"` has been removed, since they prefer that you change this through the extensions viewlet.