### PR TITLE
remove "no loops" comment

### DIFF
--- a/versioned_docs/version-2021sp/assignment3.md
+++ b/versioned_docs/version-2021sp/assignment3.md
@@ -8,7 +8,6 @@ learn about some cool JavaScript/Typescript fundamentals!
 
 ALL questions in this assignment MUST be done using `.map`, `.filter`, or
 `.reduce`. We will give you no credit for an approach that is not functional.
-You don't need for loops to solve these problems!
 
 ALL functions must also be defined using **arrow functions**:
 


### PR DESCRIPTION
Traditionally we accept solutions that use for loops to check whether a particular number is prime, so the comment that NO loops should be used in the assignment can be misleading. 