### PR TITLE
Fix typo in lecture 3 (Firebase)

### DIFF
--- a/versioned_docs/version-2021fa/lecture3.md
+++ b/versioned_docs/version-2021fa/lecture3.md
@@ -202,7 +202,7 @@ We will focus on NoSQL
   machine to store more data) while NoSQL databases tend to be horizontally
   scalable (can distribute storage and compute power on multiple machines)
 - Examples of SQL databases: MySQL, PostgreSQL
-- Examples of NoSQL databases: Fireabase, MongoDB
+- Examples of NoSQL databases: Firebase, MongoDB
 
 ### What is Firebase?
 


### PR DESCRIPTION
`Fireabase` -> `Firebase`