### PR TITLE
Update CD for main branch rename

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -2,7 +2,7 @@ name: CD
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
The branch name `master` was hardcoded in our CD so things weren't triggering after the rename