### PR TITLE
update submission instructions for A2

### DIFF
--- a/versioned_docs/version-2022sp/assignment2.md
+++ b/versioned_docs/version-2022sp/assignment2.md
@@ -107,6 +107,6 @@ If in doubt, wrap it in an anonymous function: eg. `() => console.log("hi")` vs
 ## Step 4 - Submission
 
 Once you are done, please zip up everything in your project folder EXCEPT the
-`node_modules` folder.
+`node_modules` and `.next` folders.
 
 Then submit to CMS!


### PR DESCRIPTION
The `.next` folder is large and unnecessary for grading, so students should not include it in their submission.